### PR TITLE
Add option for how triadic closure link is formed

### DIFF
--- a/examples/notebooks/undirected.ipynb
+++ b/examples/notebooks/undirected.ipynb
@@ -102,7 +102,7 @@
       "Class attribute: m\n",
       "Class values: [0, 1]\n",
       "Class labels: ['M', 'm']\n",
-      "Generation time: 1.0442118644714355 (secs)\n",
+      "Generation time: 1.013936996459961 (secs)\n",
       "=== Computed ===\n",
       "- is directed: False\n",
       "- number of nodes: 1000\n",
@@ -134,6 +134,26 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'m': 0}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g_pa.nodes[3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-04-11T17:02:55.880182Z",
@@ -160,7 +180,7 @@
       "Class attribute: m\n",
       "Class values: [0, 1]\n",
       "Class labels: ['M', 'm']\n",
-      "Generation time: 1.4631009101867676 (secs)\n",
+      "Generation time: 1.590392827987671 (secs)\n",
       "=== Computed ===\n",
       "- is directed: False\n",
       "- number of nodes: 1000\n",
@@ -193,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-04-11T17:02:55.987506Z",
@@ -210,31 +230,32 @@
       "f_m: 0.1\n",
       "k: 2\n",
       "tc: 0.8\n",
+      "tc_uniform: False\n",
       "seed: 1234\n",
       "=== Model ===\n",
       "Model: PATC\n",
       "Class attribute: m\n",
       "Class values: [0, 1]\n",
       "Class labels: ['M', 'm']\n",
-      "Generation time: 0.8242349624633789 (secs)\n",
+      "Generation time: 0.8406858444213867 (secs)\n",
       "=== Computed ===\n",
       "- is directed: False\n",
       "- number of nodes: 1000\n",
       "- number of edges: 1996\n",
       "- minimum degree: 2\n",
       "- fraction of minority: 0.1\n",
-      "- edge-type counts: Counter({'MM': 1623, 'Mm': 183, 'mM': 173, 'mm': 17})\n",
+      "- edge-type counts: Counter({'MM': 1724, 'Mm': 191, 'mM': 72, 'mm': 9})\n",
       "- density: 0.003995995995995996\n",
-      "- diameter: 10\n",
-      "- average shortest path length: 4.642116116116116\n",
+      "- diameter: 9\n",
+      "- average shortest path length: 3.521089089089089\n",
       "- average degree: 3.992\n",
-      "- degree assortativity: -0.10705617464659427\n",
-      "- attribute assortativity (m): -0.011654493942112114\n",
-      "- transitivity: 0.1287202778519904\n",
-      "- average clustering: 0.6004463626617123\n",
+      "- degree assortativity: -0.1879943957668339\n",
+      "- attribute assortativity (m): -0.006813445839098707\n",
+      "- transitivity: 0.03155594182152808\n",
+      "- average clustering: 0.6389014869734639\n",
       "- Powerlaw fit (degree):\n",
-      "- M: alpha=2.4866160646835347, sigma=0.04955386882278449, min=2.0, max=66.0\n",
-      "- m: alpha=2.4619050292765965, sigma=0.14619050292765964, min=2.0, max=36.0\n"
+      "- M: alpha=2.7689444889340002, sigma=0.05896481629780001, min=2.0, max=300.0\n",
+      "- m: alpha=2.9875826675348716, sigma=0.19875826675348715, min=2.0, max=12.0\n"
      ]
     }
    ],
@@ -247,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2023-04-11T17:02:56.130212Z",
@@ -260,7 +281,7 @@
      "output_type": "stream",
      "text": [
       "=== Params ===\n",
-      "n: 1000\n",
+      "n: 5000\n",
       "f_m: 0.1\n",
       "k: 2\n",
       "h_MM: 0.9\n",
@@ -269,31 +290,32 @@
       "[[0.9 0.1]\n",
       " [0.1 0.9]]\n",
       "tc: 0.8\n",
+      "tc_uniform: True\n",
       "seed: 1234\n",
       "=== Model ===\n",
       "Model: PATCH\n",
       "Class attribute: m\n",
       "Class values: [0, 1]\n",
       "Class labels: ['M', 'm']\n",
-      "Generation time: 1.095827341079712 (secs)\n",
+      "Generation time: 28.959617614746094 (secs)\n",
       "=== Computed ===\n",
       "- is directed: False\n",
-      "- number of nodes: 1000\n",
-      "- number of edges: 1996\n",
+      "- number of nodes: 5000\n",
+      "- number of edges: 9996\n",
       "- minimum degree: 2\n",
       "- fraction of minority: 0.1\n",
-      "- edge-type counts: Counter({'MM': 1744, 'Mm': 155, 'mM': 52, 'mm': 45})\n",
-      "- density: 0.003995995995995996\n",
-      "- diameter: 10\n",
-      "- average shortest path length: 4.708366366366366\n",
-      "- average degree: 3.992\n",
-      "- degree assortativity: -0.11255381227880877\n",
-      "- attribute assortativity (m): 0.2470086521507371\n",
-      "- transitivity: 0.13287678798254818\n",
-      "- average clustering: 0.5922042497216702\n",
+      "- edge-type counts: Counter({'MM': 8783, 'Mm': 669, 'mm': 331, 'mM': 213})\n",
+      "- density: 0.0007998399679935987\n",
+      "- diameter: 12\n",
+      "- average shortest path length: 5.406106181236248\n",
+      "- average degree: 3.9984\n",
+      "- degree assortativity: -0.06573858483668746\n",
+      "- attribute assortativity (m): 0.3809464159727494\n",
+      "- transitivity: 0.09868956837195528\n",
+      "- average clustering: 0.5875887751607352\n",
       "- Powerlaw fit (degree):\n",
-      "- M: alpha=2.4386941476748234, sigma=0.04795647158916078, min=2.0, max=61.0\n",
-      "- m: alpha=2.798272325759389, sigma=0.1798272325759389, min=2.0, max=11.0\n",
+      "- M: alpha=2.483812240200444, sigma=0.022119366899562926, min=2.0, max=141.0\n",
+      "- m: alpha=2.7738387536913764, sigma=0.07932848068754847, min=2.0, max=16.0\n",
       "- Empirical homophily within majority: None\n",
       "- Empirical homophily within minority: None\n",
       "- Empirical triadic closure: None\n"
@@ -302,14 +324,72 @@
    ],
    "source": [
     "# PATCH: Preferential attachment, homophily, and triadic closure\n",
-    "g_patch = PATCH(n=n, k=k, f_m=f_m, h_MM=h_MM, h_mm=h_mm, tc=tc, seed=seed)\n",
+    "g_patch = PATCH(n=5000, k=k, f_m=f_m, h_MM=h_MM, h_mm=h_mm, tc=tc,seed=seed)\n",
     "g_patch.generate()\n",
     "g_patch.info()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Params ===\n",
+      "n: 5000\n",
+      "f_m: 0.1\n",
+      "k: 2\n",
+      "h_MM: 0.9\n",
+      "h_mm: 0.9\n",
+      "mixing matrix: \n",
+      "[[0.9 0.1]\n",
+      " [0.1 0.9]]\n",
+      "tc: 0.8\n",
+      "tc_uniform: False\n",
+      "seed: 5\n",
+      "=== Model ===\n",
+      "Model: PATCH\n",
+      "Class attribute: m\n",
+      "Class values: [0, 1]\n",
+      "Class labels: ['M', 'm']\n",
+      "Generation time: 29.999056816101074 (secs)\n",
+      "=== Computed ===\n",
+      "- is directed: False\n",
+      "- number of nodes: 5000\n",
+      "- number of edges: 9996\n",
+      "- minimum degree: 1\n",
+      "- fraction of minority: 0.1\n",
+      "- edge-type counts: Counter({'MM': 8948, 'Mm': 691, 'mm': 307, 'mM': 50})\n",
+      "- density: 0.0007998399679935987\n",
+      "- diameter: 9\n",
+      "- average shortest path length: 3.6861122624524905\n",
+      "- average degree: 3.9984\n",
+      "- degree assortativity: -0.20279313715742991\n",
+      "- attribute assortativity (m): 0.4133769134010491\n",
+      "- transitivity: 0.008213682055535037\n",
+      "- average clustering: 0.6221149699970044\n",
+      "- Powerlaw fit (degree):\n",
+      "- M: alpha=2.8362126532689613, sigma=0.027372642092364327, min=2.0, max=986.0\n",
+      "- m: alpha=1.397992529107576, sigma=0.017798766992432078, min=1.0, max=22.0\n",
+      "- Empirical homophily within majority: None\n",
+      "- Empirical homophily within minority: None\n",
+      "- Empirical triadic closure: None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# PATCH: Preferential attachment, homophily, and triadic closure\n",
+    "g_patch = PATCH(n=n, k=k, f_m=f_m, h_MM=h_MM, h_mm=h_mm, tc=tc, tc_uniform=False, seed=seed)\n",
+    "g_patch.generate()\n",
+    "g_patch.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -331,7 +411,7 @@
       "Class attribute: m\n",
       "Class values: [0, 1]\n",
       "Class labels: ['M', 'm']\n",
-      "Generation time: 0.7464628219604492 (secs)\n",
+      "Generation time: 0.9022738933563232 (secs)\n",
       "=== Computed ===\n",
       "- is directed: False\n",
       "- number of nodes: 1000\n",
@@ -347,9 +427,7 @@
       "- attribute assortativity (m): 0.4418611113764592\n",
       "- transitivity: 0.2307913669064748\n",
       "- average clustering: 0.5546204431680304\n",
-      "- Empirical homophily within majority: None\n",
-      "- Empirical homophily within minority: None\n",
-      "- Empirical triadic closure: None\n"
+      "Could not dynamically infer attributes: <Inferring homophily not implemented yet.>\n"
      ]
     }
    ],
@@ -369,7 +447,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -414,7 +492,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -638,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -846,7 +924,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -863,7 +941,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -892,7 +970,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -921,7 +999,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -957,7 +1035,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -993,7 +1071,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {

--- a/netin/generators/patch.py
+++ b/netin/generators/patch.py
@@ -30,6 +30,9 @@ class PATCH(PAH, TriadicClosure):
     tc: float
         probability of a new edge to close a triad (minimum=0, maximum=1.)
 
+    tc_uniform: bool
+        specifies whether the triadic closure target is chosen uniform at random or if it follows the regular link formation mechanisms (e.g., homophily) (default=True)
+
     Notes
     -----
     The initialization is an undirected graph with n nodes and no edges.
@@ -45,9 +48,9 @@ class PATCH(PAH, TriadicClosure):
     # Constructor
     ############################################################
 
-    def __init__(self, n: int, k: int, f_m: float, h_mm: float, h_MM: float, tc: float, seed: object = None):
+    def __init__(self, n: int, k: int, f_m: float, h_mm: float, h_MM: float, tc: float, tc_uniform: bool = True, seed: object = None):
         PAH.__init__(self, n=n, k=k, f_m=f_m, h_MM=h_MM, h_mm=h_mm, seed=seed)
-        TriadicClosure.__init__(self, n=n, f_m=f_m, tc=tc, seed=seed)
+        TriadicClosure.__init__(self, n=n, f_m=f_m, tc=tc, tc_uniform=tc_uniform, seed=seed)
 
     ############################################################
     # Init

--- a/netin/generators/tc.py
+++ b/netin/generators/tc.py
@@ -22,6 +22,9 @@ class TriadicClosure(Graph):
     tc: float
         triadic closure probability (minimum=0, maximum=1)
 
+    tc_uniform: bool
+        specifies whether the triadic closure target is chosen uniform at random or if it follows the regular link formation mechanisms (e.g., homophily) (default=True)
+
     seed: object
         seed for random number generator
 
@@ -34,9 +37,10 @@ class TriadicClosure(Graph):
     # Constructor
     ############################################################
 
-    def __init__(self, n: int, f_m: float, tc: float, seed: object = None):
+    def __init__(self, n: int, f_m: float, tc: float, tc_uniform: bool = False, seed: object = None):
         Graph.__init__(self, n=n, f_m=f_m, seed=seed)
         self.tc = tc
+        self.tc_uniform = tc_uniform
 
     ############################################################
     # Init
@@ -67,6 +71,7 @@ class TriadicClosure(Graph):
         obj = Graph.get_metadata_as_dict(self)
         obj.update({
             'tc': self.tc,
+            'tc_uniform': self.tc_uniform
         })
         return obj
 
@@ -165,6 +170,8 @@ class TriadicClosure(Graph):
         tc_prob = np.random.random()
 
         if tc_prob < self.tc and len(special_targets) > 0:
+            if not self.tc_uniform:
+                return self.get_target_probabilities_regular(source, special_targets)
             target_set, probs = zip(*[(t, w) for t, w in special_targets.items()])
             probs = np.array(probs).astype(np.float32)
             probs /= probs.sum()
@@ -254,6 +261,7 @@ class TriadicClosure(Graph):
         Shows the parameters of the model.
         """
         print('tc: {}'.format(self.tc))
+        print('tc_uniform: {}'.format(self.tc_uniform))
 
     def info_computed(self):
         """

--- a/netin/generators/tch.py
+++ b/netin/generators/tch.py
@@ -31,6 +31,9 @@ class TCH(UnDiGraph, Homophily, TriadicClosure):
     tc: float
         probability of a new edge to close a triad (minimum=0, maximum=1.)
 
+    tc_uniform: bool
+        specifies whether the triadic closure target is chosen uniform at random or if it follows the regular link formation mechanisms (e.g., homophily) (default=True)
+
     Notes
     -----
     The initialization is an undirected graph with n nodes and no edges.
@@ -45,10 +48,10 @@ class TCH(UnDiGraph, Homophily, TriadicClosure):
     # Constructor
     ############################################################
 
-    def __init__(self, n: int, k: int, f_m: float, h_mm: float, h_MM: float, tc: float, seed: object = None):
+    def __init__(self, n: int, k: int, f_m: float, h_mm: float, h_MM: float, tc: float, tc_uniform: bool = True, seed: object = None):
         UnDiGraph.__init__(self, n, k, f_m, seed)
         Homophily.__init__(self, n=n, f_m=f_m, h_MM=h_MM, h_mm=h_mm, seed=seed)
-        TriadicClosure.__init__(self, n=n, f_m=f_m, tc=tc, seed=seed)
+        TriadicClosure.__init__(self, n=n, f_m=f_m, tc=tc, tc_uniform=tc_uniform, seed=seed)
 
     ############################################################
     # Init


### PR DESCRIPTION
Adds an option to choose how the triadic closure link is chosen.

If `tc_uniform` is set to `True` (default follows previous behavior), a target node will be chosen uniform at random from the candidate set.
Otherwise, the `get_target_probabilities_regular`-routine is executed which is implemented differently in each class. For instance, `PATCH` would bias the triadic closure links by preferential attachment and homophily.
