### PR TITLE
Make default TC special target selection unbiased.

### DIFF
--- a/docs/source/generators/undirected.rst
+++ b/docs/source/generators/undirected.rst
@@ -15,3 +15,6 @@ Undirected Graphs
 
 .. autoclass:: netin.PATCH
     :members:
+
+.. autoclass:: netin.TCH
+    :members:

--- a/netin/generators/tc.py
+++ b/netin/generators/tc.py
@@ -249,7 +249,7 @@ class TriadicClosure(Graph):
                 # G.neighbors(source) returns an iterator which would
                 # need to be searched iteratively
                 if neighbor not in self[source]:
-                    special_targets[neighbor] += 1
+                    special_targets[neighbor] = 1
         return special_targets
 
     ############################################################


### PR DESCRIPTION
Currently, selecting a special target for triadic closure (TC) is weighted by their occurrence.

That is, if a node is neighbor of two of your friends, it has a higher weight than those who you share only one common neighbor with.
This indirectly favors nodes with higher degree (having a higher chance of being friends of multiple of your friends).

Although this might be a reasonable assumption in many real world settings, it should be modelled explicitly.
For instance, one could implement a `PopularityBiasedTC` class which weights targets by the number of common neighbors with the current source node.

The default behavior, however, should remain as simple as possible which --arguably-- is random uniform selection.

_Note that_ this only applies to the case of `m>2`.