### PR TITLE
Remove special_targets and other improvements

### DIFF
--- a/netin/generators/dh.py
+++ b/netin/generators/dh.py
@@ -75,8 +75,7 @@ class DH(DiGraph, Homophily):
         DiGraph.initialize(self, class_attribute, class_values, class_labels)
         Homophily.initialize(self, class_attribute, class_values, class_labels)
 
-    def get_target_probabilities(self, source: int, available_nodes: Union[None, list[int], np.array],
-                                 special_targets: Union[None, object, iter] = None) -> np.array:
+    def get_target_probabilities(self, source: int, available_nodes: Union[None, list[int], np.array]) -> np.array:
         """
         Returns the probabilities of the target nodes to be selected given a source node.
 
@@ -97,7 +96,7 @@ class DH(DiGraph, Homophily):
             probabilities of the target nodes to be selected
 
         """
-        probs, ts = Homophily.get_target_probabilities(self, source, available_nodes, special_targets)
+        probs, ts = Homophily.get_target_probabilities(self, source, available_nodes)
         return probs
 
     ############################################################

--- a/netin/generators/directed.py
+++ b/netin/generators/directed.py
@@ -148,10 +148,6 @@ class DiGraph(nx.DiGraph, Graph):
         """
         return np.random.choice(a=np.arange(self.n), size=self.expected_number_of_edges, replace=True, p=self.activity)
 
-    def get_target_probabilities(self, source: int, available_nodes: Union[None, list[int], np.array],
-                                 special_targets: Union[None, object, iter] = None) -> np.array:
-        pass
-
     def get_target(self, source: int, edge_list: dict, **kwargs) -> Union[None, int]:
         """
         Returns a target node for a given source node.

--- a/netin/generators/dpa.py
+++ b/netin/generators/dpa.py
@@ -67,8 +67,7 @@ class DPA(DiGraph):
         """
         return self.in_degrees[n]
 
-    def get_target_probabilities(self, source: int, available_nodes: Union[None, list[int], np.array],
-                                 special_targets: Union[None, object, iter] = None) -> np.array:
+    def get_target_probabilities(self, source: int, available_nodes: Union[None, list[int], np.array]) -> np.array:
         """
         Returns the probabilities for each target node in `available_nodes` to be selected as target node
         given source node `source`.
@@ -80,9 +79,6 @@ class DPA(DiGraph):
 
         available_nodes: Set[int]
             set of target node ids
-
-        special_targets: object
-            special available_nodes
 
         Returns
         -------

--- a/netin/generators/dpah.py
+++ b/netin/generators/dpah.py
@@ -76,8 +76,7 @@ class DPAH(DPA, Homophily):
         DPA.initialize(self, class_attribute, class_values, class_labels)
         Homophily.initialize(self, class_attribute, class_values, class_labels)
 
-    def get_target_probabilities(self, source: int, available_nodes: Union[None, list[int]],
-                                 special_targets: Union[None, object, iter] = None) -> np.array:
+    def get_target_probabilities(self, source: int, available_nodes: Union[None, list[int]]) -> np.array:
         """
         Returns the probabilities of selecting a target node from a set of nodes based on
         preferential attachment and homophily, i.e., in-degree or target and homophily between source and target.
@@ -89,9 +88,6 @@ class DPAH(DPA, Homophily):
 
         available_nodes: Set[int]
             set of target nodes
-
-        special_targets: object
-            special available_nodes
 
         Returns
         -------

--- a/netin/generators/g_tc.py
+++ b/netin/generators/g_tc.py
@@ -31,9 +31,12 @@ class GraphTC(UnDiGraph, TriadicClosure):
     Notes
     -----
     The initialization is an undirected graph with n nodes and no edges.
-    Then, everytime a node is selected as source, it gets connected to k target nodes.
+    The first `k` nodes are marked as active.
+    Then, every node, starting from `k+1` is selected as source in order of their id.
+    When selected as source, a node connects to `k` active target nodes which were chosen as sources before.
     Target nodes are selected via any link formation mechanism (to be implemented in sub-classes) with probability ``1-p_{TC}``,
     and with probability ``p_{TC}`` via triadic closure (see :class:`netin.TriadicClosure`) [HolmeKim2002]_.
+    Afterwards, the source node is flagged as being active (so that subsequent sources can connect to it).
 
     Note that this model is still work in progress and not fully implemented yet.
     """
@@ -78,16 +81,16 @@ class GraphTC(UnDiGraph, TriadicClosure):
         source: int
             source node id
 
-        available_nodes: set
-            set of target node ids
+        available_nodes: List[int]
+            list of available nodes to connect to
 
-        special_targets: dict
-            dictionary of special target node ids to be considered
+        special_targets: Union[None, Dict[int, float]]
+            if present, it should be a map of a special selection of targets and their weight
 
         Returns
         -------
-        tuple
-            probabilities of nodes to be selected as target nodes, and set of target of nodes
+        Tuple[np.ndarray, List[int]]
+            probabilities of nodes to be selected as target nodes, and list of target of nodes
 
         """
         tc_prob = np.random.random()
@@ -112,7 +115,7 @@ class GraphTC(UnDiGraph, TriadicClosure):
 
     def get_special_targets(self, source: int) -> object:
         """
-        Returns an empty dictionary (source node ids)
+        Returns selection of special targets
 
         Parameters
         ----------

--- a/netin/generators/g_tc.py
+++ b/netin/generators/g_tc.py
@@ -71,8 +71,7 @@ class GraphTC(UnDiGraph, TriadicClosure):
     # Generation
     ############################################################
 
-    def get_target_probabilities(self, source: int, available_nodes: List[int],
-                                 special_targets: Union[None, Dict[int, float]] = None) -> Tuple[np.array, List[int]]:
+    def get_target_probabilities(self, source: int, available_nodes: List[int]) -> Tuple[np.array, List[int]]:
         """
         Returns the probabilities of nodes to be selected as target nodes.
 
@@ -84,9 +83,6 @@ class GraphTC(UnDiGraph, TriadicClosure):
         available_nodes: List[int]
             list of available nodes to connect to
 
-        special_targets: Union[None, Dict[int, float]]
-            if present, it should be a map of a special selection of targets and their weight
-
         Returns
         -------
         Tuple[np.ndarray, List[int]]
@@ -95,39 +91,25 @@ class GraphTC(UnDiGraph, TriadicClosure):
         """
         tc_prob = np.random.random()
 
-        if tc_prob < self.tc and len(special_targets) > 0:
+        if source != self._node_source_curr:
+            self.init_special_targets(source)
+
+        if tc_prob < self.tc and len(self._tc_candidates) > 0:
             if not self.tc_uniform:
                 # Triadic closure is uniform
                 return self.get_target_probabilities_regular(
                     source,
-                    list(special_targets.keys()))
+                    list(self._tc_candidates.keys()))
             return TriadicClosure\
-                .get_target_probabilities(self, source, available_nodes, special_targets)
+                .get_target_probabilities(self, source, available_nodes)
 
         # Edge is added based on regular mechanism (not triadic closure)
-        return self.get_target_probabilities_regular(source, available_nodes, special_targets)
+        return self.get_target_probabilities_regular(source, available_nodes)
 
     @abstractmethod
-    def get_target_probabilities_regular(self, source: int, target_list: List[int],
-                                         special_targets: Union[None, Dict[int, float]] = None) -> \
+    def get_target_probabilities_regular(self, source: int, target_list: List[int]) -> \
             Tuple[np.ndarray, List[int]]:
         raise NotImplementedError
-
-    def get_special_targets(self, source: int) -> object:
-        """
-        Returns selection of special targets
-
-        Parameters
-        ----------
-        source : int
-            Newly added node
-
-        Returns
-        -------
-        Dict
-            Empty dictionary
-        """
-        return TriadicClosure.get_special_targets(self, source)
 
     ############################################################
     # Calculations

--- a/netin/generators/g_tc.py
+++ b/netin/generators/g_tc.py
@@ -1,6 +1,5 @@
-
 from abc import abstractmethod
-from typing import Union, Dict, Any
+from typing import Union, Dict, Any, List, Tuple
 
 import numpy as np
 
@@ -69,8 +68,8 @@ class GraphTC(UnDiGraph, TriadicClosure):
     # Generation
     ############################################################
 
-    def get_target_probabilities(self, source: int, available_nodes: list[int],
-                                 special_targets: Union[None, Dict[int, float]] = None) -> tuple[np.array, list[int]]:
+    def get_target_probabilities(self, source: int, available_nodes: List[int],
+                                 special_targets: Union[None, Dict[int, float]] = None) -> Tuple[np.array, List[int]]:
         """
         Returns the probabilities of nodes to be selected as target nodes.
 
@@ -106,9 +105,9 @@ class GraphTC(UnDiGraph, TriadicClosure):
         return self.get_target_probabilities_regular(source, available_nodes, special_targets)
 
     @abstractmethod
-    def get_target_probabilities_regular(self, source: int, target_list: list[int],
-                                         special_targets: Union[None, object, iter] = None) -> \
-            tuple[np.ndarray, list[int]]:
+    def get_target_probabilities_regular(self, source: int, target_list: List[int],
+                                         special_targets: Union[None, Dict[int, float]] = None) -> \
+            Tuple[np.ndarray, List[int]]:
         raise NotImplementedError
 
     def get_special_targets(self, source: int) -> object:

--- a/netin/generators/graph.py
+++ b/netin/generators/graph.py
@@ -555,9 +555,6 @@ class Graph(nx.Graph):
         self.add_nodes_from(self.node_list)
         nx.set_node_attributes(self, self.node_class_values, self.class_attribute)
 
-    def get_special_targets(self, source: int) -> Dict[int, int]:
-        pass
-
     def get_potential_nodes_to_connect(self, source: int,
                                        available_nodes: list[int]) -> list[int]:
         """
@@ -580,8 +577,7 @@ class Graph(nx.Graph):
         return [t for t in available_nodes if t != source and t not in nx.neighbors(self, source)]
 
     def get_target_probabilities(self, source: int,
-                                 available_nodes: list[int],
-                                 special_targets: Union[None, Dict[int, int]] = None) -> tuple[np.array, list[int]]:
+                                 available_nodes: list[int] = None) -> tuple[np.array, list[int]]:
         """
         Returns the probability for each target node to be connected to the source node.
 
@@ -592,10 +588,6 @@ class Graph(nx.Graph):
 
         available_nodes:
             list of target node ids
-
-        special_targets:
-            special available_nodes to be considered (not used here)
-
 
         Notes
         -----
@@ -616,14 +608,7 @@ class Graph(nx.Graph):
         return probs, available_nodes
 
     def get_target(self, source: int,
-                   available_nodes: list[int],
-                   special_targets: Union[None, Dict[int, int]]) -> int:
-        pass
-
-    def update_special_targets(self, idx_target: int,
-                               source: int, target: int,
-                               available_nodes: list[int],
-                               special_targets: Union[None, Dict[int, int]]) -> Dict[int, int]:
+                   available_nodes: list[int]) -> int:
         pass
 
     def on_edge_added(self, source: int, target: int):

--- a/netin/generators/graph.py
+++ b/netin/generators/graph.py
@@ -1,7 +1,7 @@
 import time
 import warnings
 from collections import Counter
-from typing import Union, Iterable, Any
+from typing import Union, Iterable, Any, Dict
 
 import networkx as nx
 import numpy as np
@@ -555,7 +555,7 @@ class Graph(nx.Graph):
         self.add_nodes_from(self.node_list)
         nx.set_node_attributes(self, self.node_class_values, self.class_attribute)
 
-    def get_special_targets(self, source: int) -> object:
+    def get_special_targets(self, source: int) -> Dict[int, int]:
         pass
 
     def get_potential_nodes_to_connect(self, source: int,
@@ -581,7 +581,7 @@ class Graph(nx.Graph):
 
     def get_target_probabilities(self, source: int,
                                  available_nodes: list[int],
-                                 special_targets: Union[None, object, iter] = None) -> tuple[np.array, list[int]]:
+                                 special_targets: Union[None, Dict[int, int]] = None) -> tuple[np.array, list[int]]:
         """
         Returns the probability for each target node to be connected to the source node.
 
@@ -617,13 +617,13 @@ class Graph(nx.Graph):
 
     def get_target(self, source: int,
                    available_nodes: list[int],
-                   special_targets: Union[None, object, iter]) -> int:
+                   special_targets: Union[None, Dict[int, int]]) -> int:
         pass
 
     def update_special_targets(self, idx_target: int,
                                source: int, target: int,
                                available_nodes: list[int],
-                               special_targets: Union[None, object, iter]):
+                               special_targets: Union[None, Dict[int, int]]) -> Dict[int, int]:
         pass
 
     def on_edge_added(self, source: int, target: int):

--- a/netin/generators/h.py
+++ b/netin/generators/h.py
@@ -160,8 +160,7 @@ class Homophily(Graph):
         self.h_mm = val.calibrate_null_probabilities(self.h_mm)
         self.mixing_matrix = np.array([[self.h_MM, 1 - self.h_MM], [1 - self.h_mm, self.h_mm]])
 
-    def get_target_probabilities(self, source: int, available_nodes: Union[list[int], np.array],
-                                 special_targets: Union[None, object, iter] = None) -> tuple[np.array, list[int]]:
+    def get_target_probabilities(self, source: int, available_nodes: Union[list[int], np.array]) -> tuple[np.array, list[int]]:
         """
         Returns the probabilities of selecting a target node from a set of nodes based on homophily.
         Homophily is inferred from the mixing matrix.
@@ -208,7 +207,7 @@ class Homophily(Graph):
         """
         # Collect probabilities to connect to each node in available_nodes
         available_nodes = self.get_potential_nodes_to_connect(source, available_nodes)
-        probs, target_list = self.get_target_probabilities(source, available_nodes, special_targets)
+        probs, target_list = self.get_target_probabilities(source, available_nodes)
         return np.random.choice(a=target_list, size=1, replace=False, p=probs)[0]
 
     ############################################################

--- a/netin/generators/pa.py
+++ b/netin/generators/pa.py
@@ -42,8 +42,7 @@ class PA(UnDiGraph):
     # Generation
     ############################################################
 
-    def get_target_probabilities(self, source: int, available_nodes: list[int],
-                                 special_targets: Union[None, object, iter] = None) -> tuple[np.array, list[int]]:
+    def get_target_probabilities(self, source: int, available_nodes: list[int]) -> tuple[np.array, list[int]]:
         """
         Returns the probabilities of the target nodes to be selected given a source node.
         This probability is proportional to the degree of the target node.

--- a/netin/generators/pah.py
+++ b/netin/generators/pah.py
@@ -1,11 +1,8 @@
-from typing import Union
-
 import numpy as np
 from sympy import Eq
 from sympy import solve
 from sympy import symbols
 
-import netin
 from netin.generators.h import Homophily
 from netin.utils import constants as const
 from .pa import PA
@@ -97,8 +94,7 @@ class PAH(PA, Homophily):
         PA.initialize(self, class_attribute, class_values, class_labels)
         Homophily.initialize(self, class_attribute, class_values, class_labels)
 
-    def get_target_probabilities(self, source: int, available_nodes: list[int],
-                                 special_targets: Union[None, object, iter] = None) -> tuple[np.array, list[int]]:
+    def get_target_probabilities(self, source: int, available_nodes: list[int]) -> tuple[np.array, list[int]]:
         """
         Returns the probabilities of selecting a target node from a set of nodes based on the preferential attachment
         and homophily.

--- a/netin/generators/patc.py
+++ b/netin/generators/patc.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, List, Dict
 
 import numpy as np
 
@@ -159,8 +159,8 @@ class PATC(PA, TriadicClosure):
 
     def update_special_targets(self, idx_target: int,
                                source: int, target: int,
-                               available_nodes: list[int],
-                               special_targets: object) -> object:
+                               available_nodes: List[int],
+                               special_targets: Union[None, Dict[int, int]]) ->  Union[None, Dict[int, int]]:
         """
         Updates the set of special available_nodes based on the triadic closure mechanism.
 

--- a/netin/generators/patc.py
+++ b/netin/generators/patc.py
@@ -1,4 +1,4 @@
-from typing import Union, List, Dict
+from typing import Union, List, Dict, Tuple, Any
 
 import numpy as np
 
@@ -55,7 +55,7 @@ class PATC(GraphTC, PA):
         PA.validate_parameters(self)
         GraphTC.validate_parameters(self)
 
-    def get_metadata_as_dict(self) -> dict:
+    def get_metadata_as_dict(self) -> Dict[str, Any]:
         """
         Returns the metadata information (input parameters of the model) of the graph as a dictionary.
 
@@ -81,9 +81,9 @@ class PATC(GraphTC, PA):
         GraphTC.info_params(self)
 
     def get_target_probabilities_regular(self, source: int,
-                                         target_list: list[int],
-                                         special_targets: Union[None, object, iter] = None) -> \
-            tuple[np.array, list[int]]:
+                                         target_list: List[int],
+                                         special_targets: Union[None, Dict[int, float]] = None) -> \
+            Tuple[np.array, List[int]]:
         """
         Returns the probabilities of selecting a target node from a set of nodes based on the preferential attachment.
 
@@ -100,7 +100,7 @@ class PATC(GraphTC, PA):
 
         Returns
         -------
-        tuple[np.array, set[int]]
+        Tuple[np.array, set[int]]
             probabilities of selecting a target node from a set of nodes, and the set of target nodes
 
         See Also

--- a/netin/generators/patc.py
+++ b/netin/generators/patc.py
@@ -81,8 +81,7 @@ class PATC(GraphTC, PA):
         GraphTC.info_params(self)
 
     def get_target_probabilities_regular(self, source: int,
-                                         target_list: List[int],
-                                         special_targets: Union[None, Dict[int, float]] = None) -> \
+                                         target_list: List[int]) -> \
             Tuple[np.array, List[int]]:
         """
         Returns the probabilities of selecting a target node from a set of nodes based on the preferential attachment.
@@ -107,7 +106,7 @@ class PATC(GraphTC, PA):
         --------
         :py:meth:`get_target_probabilities() <PA.get_target_probabilities>` in :class:`netin.PA`.
         """
-        return PA.get_target_probabilities(self, source, target_list, special_targets)
+        return PA.get_target_probabilities(self, source, target_list)
 
     ############################################################
     # Calculations

--- a/netin/generators/patc.py
+++ b/netin/generators/patc.py
@@ -2,12 +2,12 @@ from typing import Union, List, Dict
 
 import numpy as np
 
-from netin.generators.tc import TriadicClosure
 from netin.utils import constants as const
 from .pa import PA
+from .g_tc import GraphTC
 
 
-class PATC(PA, TriadicClosure):
+class PATC(GraphTC, PA):
     """Creates a new PATC instance. An undirected graph with preferential attachment and triadic closure.
 
     Parameters
@@ -41,7 +41,7 @@ class PATC(PA, TriadicClosure):
 
     def __init__(self, n: int, k: int, f_m: float, tc: float, seed: object = None):
         PA.__init__(self, n=n, k=k, f_m=f_m, seed=seed)
-        TriadicClosure.__init__(self, n=n, f_m=f_m, tc=tc, seed=seed)
+        GraphTC.__init__(self, n=n, k=k, f_m=f_m, tc=tc, seed=seed)
         self.model_name = const.PATC_MODEL_NAME
 
     ############################################################
@@ -53,7 +53,7 @@ class PATC(PA, TriadicClosure):
         Validates the parameters of the undirected.
         """
         PA.validate_parameters(self)
-        TriadicClosure.validate_parameters(self)
+        GraphTC.validate_parameters(self)
 
     def get_metadata_as_dict(self) -> dict:
         """
@@ -65,7 +65,7 @@ class PATC(PA, TriadicClosure):
             Dictionary with the graph's metadata
         """
         obj1 = PA.get_metadata_as_dict(self)
-        obj2 = TriadicClosure.get_metadata_as_dict(self)
+        obj2 = GraphTC.get_metadata_as_dict(self)
         obj1.update(obj2)
         return obj1
 
@@ -78,55 +78,7 @@ class PATC(PA, TriadicClosure):
         Shows the parameters of the model.
         """
         PA.info_params(self)
-        TriadicClosure.info_params(self)
-
-    def get_special_targets(self, source: int) -> object:
-        """
-        Returns the initial set of special available_nodes based on the triadic closure mechanism.
-
-        Parameters
-        ----------
-        source : int
-             Newly added node
-
-        Returns
-        -------
-        object
-            Empty dictionary (source node ids)
-
-        See Also
-        --------
-        :py:meth:`get_special_targets() <TriadicClosure.get_special_targets>` in :class:`netin.TC`.
-        """
-        return TriadicClosure.get_special_targets(self, source)
-
-    def get_target_probabilities(self, source: int, available_nodes: list[int],
-                                 special_targets: Union[None, object, iter] = None) -> tuple[np.array, list[int]]:
-        """
-        Returns the probabilities of selecting a target node from a set of nodes based on the preferential attachment
-        or triadic closure.
-
-        Parameters
-        ----------
-        source: int
-            source node
-
-        available_nodes: set[int]
-            set of target nodes
-
-        special_targets: object
-            special available_nodes
-
-        Returns
-        -------
-        tuple[np.array, set[int]]
-            probabilities of selecting a target node from a set of nodes, and the set of target nodes
-
-        See Also
-        --------
-        :py:meth:`get_target_probabilities() <TriadicClosure.get_target_probabilities>` in :class:`netin.TC`.
-        """
-        return TriadicClosure.get_target_probabilities(self, source, available_nodes, special_targets)
+        GraphTC.info_params(self)
 
     def get_target_probabilities_regular(self, source: int,
                                          target_list: list[int],
@@ -157,57 +109,9 @@ class PATC(PA, TriadicClosure):
         """
         return PA.get_target_probabilities(self, source, target_list, special_targets)
 
-    def update_special_targets(self, idx_target: int,
-                               source: int, target: int,
-                               available_nodes: List[int],
-                               special_targets: Union[None, Dict[int, int]]) ->  Union[None, Dict[int, int]]:
-        """
-        Updates the set of special available_nodes based on the triadic closure mechanism.
-
-        Parameters
-        ----------
-        idx_target: int
-            index of the target node
-
-        source: int
-            source node
-
-        target: int
-            target node
-
-        available_nodes: Set[int]
-            set of target nodes
-
-        special_targets: object
-            special available_nodes
-
-        Returns
-        -------
-        object
-            updated special available_nodes
-
-        See Also
-        --------
-        :func:`netin.TC.update_special_targets`
-
-        """
-        return TriadicClosure.update_special_targets(self, idx_target, source, target, available_nodes, special_targets)
-
     ############################################################
     # Calculations
     ############################################################
-
-    def infer_triadic_closure(self) -> float:
-        """
-        Approximates analytically the triadic closure value of the graph.
-
-        Returns
-        -------
-        float
-            triadic closure probability of the graph
-        """
-        tc = infer_triadic_closure(self)
-        return tc
 
     def makecopy(self):
         """
@@ -256,7 +160,6 @@ class PATC(PA, TriadicClosure):
         new_g.generate()
 
         return new_g
-
 
 def infer_triadic_closure(g):
     import networkx as nx

--- a/netin/generators/patch.py
+++ b/netin/generators/patch.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Dict, Any, List, Tuple
 
 import numpy as np
 
@@ -64,7 +64,7 @@ class PATCH(GraphTC, PAH):
         PAH.validate_parameters(self)
         GraphTC.validate_parameters(self)
 
-    def get_metadata_as_dict(self) -> dict:
+    def get_metadata_as_dict(self) -> Dict[str, Any]:
         """
         Returns a dictionary with the metadata of the PATCH graph.
 
@@ -82,8 +82,8 @@ class PATCH(GraphTC, PAH):
     # Generation
     ############################################################
     def get_target_probabilities_regular(self, source: int,
-                                         available_nodes: list[int],
-                                         special_targets: Union[None, object, iter] = None) -> tuple[np.ndarray, list[int]]:
+                                         target_list: List[int],
+                                         special_targets: Union[None, Dict[int, float]] = None) -> Tuple[np.ndarray, List[int]]:
         """
         Returns the probability of nodes to be selected as target nodes using the
         preferential attachment with homophily mechanism.
@@ -104,7 +104,7 @@ class PATCH(GraphTC, PAH):
         tuple
             probabilities of nodes to be selected as target nodes, and set of target of nodes
         """
-        return PAH.get_target_probabilities(self, source, available_nodes, special_targets)
+        return PAH.get_target_probabilities(self, source, target_list, special_targets)
 
     ############################################################
     # Calculations

--- a/netin/generators/patch.py
+++ b/netin/generators/patch.py
@@ -2,12 +2,12 @@ from typing import Union
 
 import numpy as np
 
-from netin.generators.tc import TriadicClosure
 from netin.utils import constants as const
 from .pah import PAH
+from .g_tc import GraphTC
 
 
-class PATCH(PAH, TriadicClosure):
+class PATCH(GraphTC, PAH):
     """Creates a new PATCH instance. An undirected graph with preferential attachment, homophily, and triadic closure.
 
     Parameters
@@ -39,7 +39,7 @@ class PATCH(PAH, TriadicClosure):
     Then, everytime a node is selected as source, it gets connected to k target nodes.
     Target nodes are selected via preferential attachment (in-degree) [BarabasiAlbert1999]_ and
     homophily (h_**; see :class:`netin.Homophily`) [Karimi2018]_ with probability ``1-p_{TC}``,
-    and with probability ``p_{TC}`` via triadic closure (see :class:`netin.TriadicClosure`) [HolmeKim2002]_.
+    and with probability ``p_{TC}`` via triadic closure (see :class:`netin.GraphTC`) [HolmeKim2002]_.
 
     Note that this model is still work in progress and not fully implemented yet.
     """
@@ -50,7 +50,7 @@ class PATCH(PAH, TriadicClosure):
 
     def __init__(self, n: int, k: int, f_m: float, h_mm: float, h_MM: float, tc: float, tc_uniform: bool = True, seed: object = None):
         PAH.__init__(self, n=n, k=k, f_m=f_m, h_MM=h_MM, h_mm=h_mm, seed=seed)
-        TriadicClosure.__init__(self, n=n, f_m=f_m, tc=tc, tc_uniform=tc_uniform, seed=seed)
+        GraphTC.__init__(self, n=n, k=k, f_m=f_m, tc=tc, tc_uniform=tc_uniform, seed=seed)
         self.model_name = const.PATCH_MODEL_NAME
 
     ############################################################
@@ -62,7 +62,7 @@ class PATCH(PAH, TriadicClosure):
         Validates the parameters of the undirected.
         """
         PAH.validate_parameters(self)
-        TriadicClosure.validate_parameters(self)
+        GraphTC.validate_parameters(self)
 
     def get_metadata_as_dict(self) -> dict:
         """
@@ -74,39 +74,13 @@ class PATCH(PAH, TriadicClosure):
             the graph  metadata as a dictionary
         """
         obj1 = PAH.get_metadata_as_dict(self)
-        obj2 = TriadicClosure.get_metadata_as_dict(self)
+        obj2 = GraphTC.get_metadata_as_dict(self)
         obj1.update(obj2)
         return obj1
 
     ############################################################
     # Generation
     ############################################################
-
-    def get_target_probabilities(self, source: int,
-                                 available_nodes: list[int],
-                                 special_targets: Union[None, object, iter] = None) -> tuple[np.array, list[int]]:
-        """
-        Returns the probabilities of nodes to be selected as target nodes.
-
-        Parameters
-        ----------
-        source: int
-            source node id
-
-        available_nodes: set
-            set of target node ids
-
-        special_targets: dict
-            dictionary of special target node ids to be considered
-
-        Returns
-        -------
-        tuple
-            probabilities of nodes to be selected as target nodes, and set of target of nodes
-
-        """
-        return TriadicClosure.get_target_probabilities(self, source, available_nodes, special_targets)
-
     def get_target_probabilities_regular(self, source: int,
                                          available_nodes: list[int],
                                          special_targets: Union[None, object, iter] = None) -> tuple[np.ndarray, list[int]]:
@@ -132,22 +106,6 @@ class PATCH(PAH, TriadicClosure):
         """
         return PAH.get_target_probabilities(self, source, available_nodes, special_targets)
 
-    def get_special_targets(self, source: int) -> object:
-        """
-        Returns an empty dictionary (source node ids)
-
-        Parameters
-        ----------
-        source : int
-            Newly added node
-
-        Returns
-        -------
-        Dict
-            Empty dictionary
-        """
-        return TriadicClosure.get_special_targets(self, source)
-
     ############################################################
     # Calculations
     ############################################################
@@ -157,14 +115,14 @@ class PATCH(PAH, TriadicClosure):
         Shows the (input) parameters of the graph.
         """
         PAH.info_params(self)
-        TriadicClosure.info_params(self)
+        GraphTC.info_params(self)
 
     def info_computed(self):
         """
         Shows the (computed) properties of the graph.
         """
         PAH.info_computed(self)
-        TriadicClosure.info_computed(self)
+        GraphTC.info_computed(self)
 
     def infer_homophily_values(self) -> tuple[float, float]:
         """

--- a/netin/generators/patch.py
+++ b/netin/generators/patch.py
@@ -82,8 +82,7 @@ class PATCH(GraphTC, PAH):
     # Generation
     ############################################################
     def get_target_probabilities_regular(self, source: int,
-                                         target_list: List[int],
-                                         special_targets: Union[None, Dict[int, float]] = None) -> Tuple[np.ndarray, List[int]]:
+                                         target_list: List[int]) -> Tuple[np.ndarray, List[int]]:
         """
         Returns the probability of nodes to be selected as target nodes using the
         preferential attachment with homophily mechanism.
@@ -104,7 +103,10 @@ class PATCH(GraphTC, PAH):
         tuple
             probabilities of nodes to be selected as target nodes, and set of target of nodes
         """
-        return PAH.get_target_probabilities(self, source, target_list, special_targets)
+        return PAH.get_target_probabilities(self, source, target_list)
+
+    def get_target_probabilities(self, source: int, available_nodes: List[int]) -> Tuple[Any, List[int]]:
+        return GraphTC.get_target_probabilities(self, source, available_nodes)
 
     ############################################################
     # Calculations

--- a/netin/generators/tc.py
+++ b/netin/generators/tc.py
@@ -1,13 +1,12 @@
 from collections import defaultdict
 from typing import Union
-from typing import List, Iterable, Any, Tuple, Dict
+from typing import List, Any, Tuple, Dict
 
 import numpy as np
 
 from netin.utils import constants as const
 from netin.utils import validator as val
 from .graph import Graph
-
 
 class TriadicClosure(Graph):
     """Class to model triadic closure as a mechanism of edge formation given a source and a target node.
@@ -136,7 +135,7 @@ class TriadicClosure(Graph):
 
     def get_target_probabilities(self, source: int,
                                  available_nodes: List[int],
-                                 special_targets: Union[None, Iterable] = None) -> Tuple[np.array, List[int]]:
+                                 special_targets: Union[None, Dict[int, float]] = None) -> Tuple[np.array, List[int]]:
         """Returns the probabilities of selecting a target node from a set of nodes based on triadic closure, or a regular mechanism,
 
         Parameters
@@ -145,7 +144,7 @@ class TriadicClosure(Graph):
             source node
         available_nodes : List[int]
             list of available target nodes
-        special_targets : Union[None, Iteratable], optional
+        special_targets : Union[None, Dict[int, float]], optional
             List of limited target nodes, by default None
 
         Returns
@@ -155,7 +154,7 @@ class TriadicClosure(Graph):
             The first list contains the probabilities and the second list the available nodes.
         """
         # Triadic closure is not uniform (biased towards common neighbors)
-        available_nodes, probs = zip(*[(t, w) for t, w in special_targets.items()])
+        available_nodes, probs = zip(*list(special_targets.items()))
         probs = np.array(probs).astype(np.float32)
         probs /= probs.sum()
         return probs, available_nodes

--- a/netin/generators/tc.py
+++ b/netin/generators/tc.py
@@ -23,9 +23,6 @@ class TriadicClosure(Graph):
     tc: float
         triadic closure probability (minimum=0, maximum=1)
 
-    tc_uniform: bool
-        specifies whether the triadic closure target is chosen uniform at random or if it follows the regular link formation mechanisms (e.g., homophily) (default=True)
-
     seed: object
         seed for random number generator
 
@@ -38,10 +35,9 @@ class TriadicClosure(Graph):
     # Constructor
     ############################################################
 
-    def __init__(self, n: int, f_m: float, tc: float, tc_uniform: bool = False, seed: object = None):
+    def __init__(self, n: int, f_m: float, tc: float, seed: object = None):
         Graph.__init__(self, n=n, f_m=f_m, seed=seed)
         self.tc = tc
-        self.tc_uniform = tc_uniform
         self.model_name = const.TC_MODEL_NAME
 
     ############################################################
@@ -66,8 +62,7 @@ class TriadicClosure(Graph):
         """
         obj = Graph.get_metadata_as_dict(self)
         obj.update({
-            'tc': self.tc,
-            'tc_uniform': self.tc_uniform
+            'tc': self.tc
         })
         return obj
 
@@ -159,21 +154,11 @@ class TriadicClosure(Graph):
             Tuple of two equally sizes lists.
             The first list contains the probabilities and the second list the available nodes.
         """
-        tc_prob = np.random.random()
-
-        if tc_prob < self.tc and len(special_targets) > 0:
-            # Edge is added based on triadic closure
-            if not self.tc_uniform:
-                # Triadic closure is uniform
-                return self.get_target_probabilities_regular(source, list(special_targets.keys()))
-            # Triadic closure is not uniform (biased towards common neighbors)
-            available_nodes, probs = zip(*[(t, w) for t, w in special_targets.items()])
-            probs = np.array(probs).astype(np.float32)
-            probs /= probs.sum()
-            return probs, available_nodes
-
-        # Edge is added based on regular mechanism (not triadic closure)
-        return self.get_target_probabilities_regular(source, available_nodes, special_targets)
+        # Triadic closure is not uniform (biased towards common neighbors)
+        available_nodes, probs = zip(*[(t, w) for t, w in special_targets.items()])
+        probs = np.array(probs).astype(np.float32)
+        probs /= probs.sum()
+        return probs, available_nodes
 
     def get_target(self, source: int,
                    available_nodes: List[int],
@@ -255,7 +240,6 @@ class TriadicClosure(Graph):
         Shows the parameters of the model.
         """
         print('tc: {}'.format(self.tc))
-        print('tc_uniform: {}'.format(self.tc_uniform))
 
     def info_computed(self):
         """

--- a/netin/generators/tc.py
+++ b/netin/generators/tc.py
@@ -160,30 +160,6 @@ class TriadicClosure(Graph):
         probs /= probs.sum()
         return probs, available_nodes
 
-    def get_target(self, source: int,
-                   available_nodes: List[int],
-                   special_targets: Union[None, Iterable]) -> int:
-        """Picks a random target node based on the homophily/preferential attachment dynamic.
-
-        Parameters
-        ----------
-        source : int
-            Newly added node
-        available_nodes : List[int]
-            Potential target nodes in the graph
-        special_targets : Union[None, Iteratable]
-            Limited target nodes
-
-        Returns
-        -------
-        int
-            Target node that and edge should be created to from `source`
-        """
-        # Collect probabilities to connect to each node in available_nodes
-        target_set = self.get_potential_nodes_to_connect(source, available_nodes)
-        probs = self.get_target_probabilities(source, target_set, special_targets)
-        return np.random.choice(a=target_set, size=1, replace=False, p=probs)[0]
-
     def update_special_targets(self,
                                idx_target: int,
                                source: int, target: int,

--- a/netin/generators/tch.py
+++ b/netin/generators/tch.py
@@ -56,8 +56,7 @@ class TCH(GraphTC, Homophily):
     ############################################################
     # Generation
     ############################################################
-    def get_target_probabilities_regular(self, source: int, target_list: list[int],
-                                         special_targets: Union[None, object, iter] = None) -> \
+    def get_target_probabilities_regular(self, source: int, target_list: list[int]) -> \
             tuple[np.ndarray, list[int]]:
         """
         Returns the probability of nodes to be selected as target nodes using the homophily mechanism.
@@ -78,7 +77,7 @@ class TCH(GraphTC, Homophily):
         tuple
             probabilities of nodes to be selected as target nodes, and set of target of nodes
         """
-        return Homophily.get_target_probabilities(self=self, source=source, available_nodes=target_list, special_targets=special_targets)
+        return Homophily.get_target_probabilities(self=self, source=source, available_nodes=target_list)
 
     ############################################################
     # Calculations

--- a/netin/generators/tch.py
+++ b/netin/generators/tch.py
@@ -78,9 +78,7 @@ class TCH(GraphTC, Homophily):
         tuple
             probabilities of nodes to be selected as target nodes, and set of target of nodes
         """
-        probs = np.asarray(
-            [self.get_homophily_between_source_and_target(source, target) + const.EPSILON for target in target_list])
-        return probs / probs.sum(), target_list
+        return Homophily.get_target_probabilities(self=self, source=source, available_nodes=target_list, special_targets=special_targets)
 
     ############################################################
     # Calculations

--- a/netin/generators/tests/test_patch.py
+++ b/netin/generators/tests/test_patch.py
@@ -23,7 +23,8 @@ class TestPATCH(object):
         c3 = g.calculate_minimum_degree() == k
         c4 = g.calculate_fraction_of_minority() == f_m
         c5 = g.model_name == const.PATCH_MODEL_NAME
-        assert c1 and c2 and c3 and c4 and c5, "Incorrect undirected parameters."
+        c6 = sum(k for _, k in g.degree()) == ((k*(k-1)) + ((n-k)*k*2))
+        assert c1 and c2 and c3 and c4 and c5 and c6, "Incorrect undirected parameters."
 
     def test_patch_case_2(self):
         n = 200
@@ -40,7 +41,8 @@ class TestPATCH(object):
         c3 = g.calculate_minimum_degree() == k
         c4 = g.calculate_fraction_of_minority() == f_m
         c5 = g.model_name == const.PATCH_MODEL_NAME
-        assert c1 and c2 and c3 and c4 and c5, "Incorrect undirected parameters."
+        c6 = sum(k for _, k in g.degree()) == ((k*(k-1)) + ((n-k)*k*2))
+        assert c1 and c2 and c3 and c4 and c5 and c6, "Incorrect undirected parameters."
 
     def test_patch_case_3(self):
         n = 200
@@ -57,7 +59,8 @@ class TestPATCH(object):
         c3 = g.calculate_minimum_degree() == k
         c4 = g.calculate_fraction_of_minority() == f_m
         c5 = g.model_name == const.PATCH_MODEL_NAME
-        assert c1 and c2 and c3 and c4 and c5, "Incorrect undirected parameters."
+        c6 = sum(k for _, k in g.degree()) == ((k*(k-1)) + ((n-k)*k*2))
+        assert c1 and c2 and c3 and c4 and c5 and c6, "Incorrect undirected parameters."
 
     def test_patch_case_4(self):
         n = 200
@@ -74,7 +77,8 @@ class TestPATCH(object):
         c3 = g.calculate_minimum_degree() == k
         c4 = g.calculate_fraction_of_minority() == f_m
         c5 = g.model_name == const.PATCH_MODEL_NAME
-        assert c1 and c2 and c3 and c4 and c5, "Incorrect undirected parameters."
+        c6 = sum(k for _, k in g.degree()) == ((k*(k-1)) + ((n-k)*k*2))
+        assert c1 and c2 and c3 and c4 and c5 and c6, "Incorrect undirected parameters."
 
     def test_patch_case_5(self):
         n = 200

--- a/netin/generators/tests/test_patch.py
+++ b/netin/generators/tests/test_patch.py
@@ -1,5 +1,7 @@
 import pytest
 
+import networkx as nx
+
 from netin import PATCH
 from netin.utils import constants as const
 
@@ -100,3 +102,21 @@ class TestPATCH(object):
         seed = 1234
         with pytest.raises(TypeError, match="missing 3 required positional arguments: 'h_mm', 'h_MM', and 'tc'"):
             _ = PATCH(n=n, k=k, f_m=f_m, seed=seed)
+
+    def test_patch_ccf_increase(self):
+        """Test that increasing TC probabilities lead to higher clustering coefficients.
+        """
+        n = 200
+        k = 2
+        f_m = 0.1
+        seed = 1234
+        h = .5
+        tc = [0., .25, .5, .75, 1.]
+
+        l_g = [PATCH(n=n, k=k, f_m=f_m, seed=seed, tc=p_tc, h_MM=h, h_mm=h) for p_tc in tc]
+        l_ccf = []
+        for g in l_g:
+            g.generate()
+            l_ccf.append(nx.average_clustering(g))
+
+        assert(all(l_ccf[i] > l_ccf[i-1] for i in range(1, len(l_ccf))))

--- a/netin/generators/tests/test_undirected.py
+++ b/netin/generators/tests/test_undirected.py
@@ -19,7 +19,8 @@ class TestUnDiGraph(object):
         c3 = g.calculate_minimum_degree() == k
         c4 = g.calculate_fraction_of_minority() == f_m
         c5 = g.model_name == const.PA_MODEL_NAME
-        assert c1 and c2 and c3 and c4 and c5, "Incorrect undirected parameters."
+        c6 = sum(k for _, k in g.degree()) == ((k*(k-1)) + ((n-k)*k*2))
+        assert c1 and c2 and c3 and c4 and c5 and c6, "Incorrect undirected parameters."
 
     def test_patch_case_pah(self):
         n = 200
@@ -35,7 +36,8 @@ class TestUnDiGraph(object):
         c3 = g.calculate_minimum_degree() == k
         c4 = g.calculate_fraction_of_minority() == f_m
         c5 = g.model_name == const.PAH_MODEL_NAME
-        assert c1 and c2 and c3 and c4 and c5, "Incorrect undirected parameters."
+        c6 = sum(k for _, k in g.degree()) == ((k*(k-1)) + ((n-k)*k*2))
+        assert c1 and c2 and c3 and c4 and c5 and c6, "Incorrect undirected parameters."
 
     def test_case_patc(self):
         n = 200
@@ -50,7 +52,8 @@ class TestUnDiGraph(object):
         c3 = g.calculate_minimum_degree() == k
         c4 = g.calculate_fraction_of_minority() == f_m
         c5 = g.model_name == const.PATC_MODEL_NAME
-        assert c1 and c2 and c3 and c4 and c5, "Incorrect undirected parameters."
+        c6 = sum(k for _, k in g.degree()) == ((k*(k-1)) + ((n-k)*k*2))
+        assert c1 and c2 and c3 and c4 and c5 and c6, "Incorrect undirected parameters."
 
     def test_case_patch(self):
         n = 200
@@ -67,7 +70,8 @@ class TestUnDiGraph(object):
         c3 = g.calculate_minimum_degree() == k
         c4 = g.calculate_fraction_of_minority() == f_m
         c5 = g.model_name == const.PATCH_MODEL_NAME
-        assert c1 and c2 and c3 and c4 and c5, "Incorrect undirected parameters."
+        c6 = sum(k for _, k in g.degree()) == ((k*(k-1)) + ((n-k)*k*2))
+        assert c1 and c2 and c3 and c4 and c5 and c6, "Incorrect undirected parameters."
 
     def test_case_all(self):
         n = 200

--- a/netin/generators/undirected.py
+++ b/netin/generators/undirected.py
@@ -117,6 +117,13 @@ class UnDiGraph(Graph):
         probs, targets = self.get_target_probabilities(source, available_nodes, special_targets)
         return np.random.choice(a=targets, size=1, replace=False, p=probs)[0]
 
+    def _link_init_nodes(self):
+        for source in self.node_list[:self.k]:
+            for target in self.node_list[:self.k]:
+                if (source != target) and (target not in self[source]):
+                    self.add_edge(source, target)
+                    self.on_edge_added(source, target)
+
     def generate(self):
         """
         An undirected graph of n nodes is grown by attaching new nodes each with k edges.
@@ -136,6 +143,7 @@ class UnDiGraph(Graph):
         """
         # 1. Init an undirected graph and nodes (assign class labels)
         super().generate()
+        self._link_init_nodes()
 
         # 2. Iterate until n nodes are added (starts with k pre-existing, unconnected nodes)
         for source in self.node_list[self.k:]:

--- a/netin/generators/undirected.py
+++ b/netin/generators/undirected.py
@@ -91,15 +91,12 @@ class UnDiGraph(Graph):
 
     def get_target(self,
                    source: int,
-                   available_nodes: list[int],
-                   special_targets: Union[None, object, iter]) -> int:
+                   available_nodes: list[int]) -> int:
         """
         Picks a random target node based on preferential attachment.
 
         Parameters
         ----------
-        special_targets : object
-            Special available_nodes to be considered
 
         source: int
             Newly added node
@@ -114,7 +111,7 @@ class UnDiGraph(Graph):
         """
         # Collect probabilities to connect to each node in available_nodes
         available_nodes = self.get_potential_nodes_to_connect(source, available_nodes)
-        probs, targets = self.get_target_probabilities(source, available_nodes, special_targets)
+        probs, targets = self.get_target_probabilities(source, available_nodes)
         return np.random.choice(a=targets, size=1, replace=False, p=probs)[0]
 
     def _link_init_nodes(self):
@@ -148,17 +145,10 @@ class UnDiGraph(Graph):
         # 2. Iterate until n nodes are added (starts with k pre-existing, unconnected nodes)
         for source in self.node_list[self.k:]:
             available_nodes = np.arange(source).tolist()  # available_nodes via preferential attachment
-            special_targets = self.get_special_targets(source)
 
-            for idx_target in range(self.k):
+            for _ in range(self.k):
                 # Choose next target
-                target = self.get_target(source, available_nodes, special_targets)
-
-                special_targets = self.update_special_targets(idx_target,
-                                                              source,
-                                                              target,
-                                                              available_nodes,
-                                                              special_targets)
+                target = self.get_target(source, available_nodes)
 
                 # Finally add edge to undirected
                 self.add_edge(source, target)


### PR DESCRIPTION
This pull request bundles the following improvements:

## Initial nodes begin fully connected
By fully connecting the first `k` nodes, they will start with a degree of `k-1`. The update rule starts with node `k+1` which will connect to all existing `k` nodes as there are no duplicates allowed. After `k+1` joined, all nodes will thus have degree `k`. This sets the minimum degree to `k` and avoids isolated nodes.

## Improved tests
Test cases are improved to test for minimum degree `k`, exact number of links and increasing graph clustering when triadic closure is used.

## Code simplification
Improved type hints, documentation and removed redundant code.

More importantly, models with triadic closure are simplified. The class `netin.TriadicClosure` is now responsible for keeping track of triadic closure candidates (898528c3004c0a62e5bc19872976657a05f6cebc) and for performing the actual tc-based target selection. As only triadic closure model variants need to keep track of respective tc candidates, this functionality is now bundled in `netin.TriadicClosure` and removed from all super classes. Moreover, `netin.TriadicClosure` makes use of the existing `on_edge_added`-method to update the candidates.

Whether tc (or another mechanism) is chosen, should be implemented in the actual model implementations. For this purpose, a single base class `netin.GraphTC` is introduced in b7b8cc3c37a06be20226d46146748cca6dd3a682.
This class performs the decision whether tc is executed or whether an alternative mechanism is chosen.
Concrete model variants (e.g., `netin.PATCH` or `netin.TCH`) then inherit from `netin.GraphTC` and only reimplement `GraphTC.get_probabilities_regular` to specify which exact alternative to triadic closure is performed.
