### PR TITLE
Adding how to cite in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,67 @@ Released under Creative Commons by-nc-sa 4.0 (see `LICENSE`)::
    Lisette Espin-Noboa <espin@csh.ac.at>
    Jan Bachmann <bachmann@csh.ac.at>
 
+How to cite
+-----------
+
+If you use any implementation from this repository, please cite both the repository and the corresponding paper as follows:
+
+1. Citing the GitHub repository
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bibtex
+
+   @misc{pynetin,
+     author = {{CSH Algorithmic Fairness and Network Inequality Group}},
+     title = {{NetworkInequalities}},
+     year = {2023},
+     publisher = {GitHub},
+     journal = {GitHub repository},
+     howpublished = {\url{https://github.com/CSHVienna/NetworkInequalities}}
+   }
+
+
+2. Citing the models from the original papers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+PAH model
+^^^^^^^^^
+
+.. code-block:: bibtex
+
+  @article{karimi2018homophily,
+      title={Homophily influences ranking of minorities in social networks},
+      author={Karimi, Fariba and G{\'e}nois, Mathieu and Wagner, Claudia and Singer, Philipp and Strohmaier, Markus},
+      journal={Scientific reports},
+      volume={8},
+      number={1},
+      pages={11077},
+      year={2018},
+      publisher={Nature Publishing Group UK London}
+  }
+
+
+DPAH, DPA, DH models
+^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bibtex
+
+  @article{espin2022inequality,
+      title={Inequality and inequity in network-based ranking and recommendation algorithms},
+      author={Esp{\'\i}n-Noboa, Lisette and Wagner, Claudia and Strohmaier, Markus and Karimi, Fariba},
+      journal={Scientific reports},
+      volume={12},
+      number={1},
+      pages={2012},
+      year={2022},
+      publisher={Nature Publishing Group UK London}
+  }
+
+
+Thank you for citing our work! 🚀
+
+
+
 Note on multidimensional interactions
 ----------------------------------------------------
 Provisionally, the code to simulate and analyze networks with multidimensional interactions is hosted in the `repository <https://github.com/CSHVienna/multidimensional_social_interactions_paper>`_ associated with the `paper <https://arxiv.org/abs/2406.17043>`_ [Martin-Gutierrez et al. 2024].

--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ If you use any implementation from this repository, please cite both the reposit
 
 .. code-block:: bibtex
 
-   @misc{pynetin,
+   @software{pynetin,
      author = {{CSH Algorithmic Fairness and Network Inequality Group}},
      title = {{NetworkInequalities}},
      year = {2023},
@@ -142,6 +142,17 @@ DPAH, DPA, DH models
       publisher={Nature Publishing Group UK London}
   }
 
+PATCH model
+^^^^^^^^^^^
+
+.. code-block:: bibtex
+
+    @unpublished{bachmann2025patch,
+      author    = {Bachmann, Jan and Esp{\'i}n-Noboa, Lisette and Cinardi, Nicola and Martin-Gutierrez, Samuel and Karimi, Fariba},
+      title     = {PATCH: Network Inequality through Preferential Attachment, Triadic Closure and Homophily},
+      year      = {2025},
+      note      = {Work in progress},
+    }
 
 Thank you for citing our work! 🚀
 


### PR DESCRIPTION
Hi @mannbach, I have added in the README a section on "how to cite" this work.
Since the package is based on multiple papers, it is not fair to use the "citation.cff" widget from GitHub.
So, I added a few lines on the README.rst file.

Could you please review this change and accept it if you think it is ok?
Otherwise, pleas let me know what else should we include/remove.

PS. PATCH in this version is implemented, can we already cite it?
Thanks!